### PR TITLE
feat(parse): parse xml-like profile strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,6 @@ dependencies = [
 name = "dbot"
 version = "0.0.0"
 dependencies = [
- "dotfish",
  "globset",
  "once_cell",
  "serde",
@@ -101,11 +100,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
-
-[[package]]
-name = "dotfish"
-version = "0.0.0"
-source = "git+https://github.com/loichyan/dotfish#16bbf7b4645909ab7b1d289d26e10d79ea3fde7d"
 
 [[package]]
 name = "fastrand"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
 [[package]]
 name = "thisctx"
 version = "0.1.0"
-source = "git+https://github.com/loichyan/thisctx#c05e6e7a54554f49ef618209c5afbc17f1c10fa8"
+source = "git+https://github.com/loichyan/thisctx#173780b56bd648a76ca45039f2e8a3b58434a63c"
 dependencies = [
  "thisctx_impl",
 ]
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "thisctx_impl"
 version = "0.1.0"
-source = "git+https://github.com/loichyan/thisctx#c05e6e7a54554f49ef618209c5afbc17f1c10fa8"
+source = "git+https://github.com/loichyan/thisctx#173780b56bd648a76ca45039f2e8a3b58434a63c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 
-[dependencies.dotfish]
-git = "https://github.com/loichyan/dotfish"
-
 [dependencies.serde]
 version = "1.0"
 features = ["derive"]

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -6,8 +6,7 @@ use thisctx::WithContext;
 fn create_symlink(original: &Path, link: &Path) -> error::Result<()> {
     #[cfg(unix)]
     {
-        std::os::unix::fs::symlink(original, link)
-            .context(error::IoFailedContext { path: original })?;
+        std::os::unix::fs::symlink(original, link).context(error::IoFailed { path: original })?;
     }
     #[cfg(not(unix))]
     {
@@ -20,17 +19,17 @@ fn create_symlink(original: &Path, link: &Path) -> error::Result<()> {
 pub fn apply(renderer: &mut Renderer, entries: &CompiledEntries) -> error::Result<()> {
     for (target, profile) in entries.iter() {
         if let Some(dir) = target.parent() {
-            std::fs::create_dir_all(dir).context(error::IoFailedContext { path: dir })?;
+            std::fs::create_dir_all(dir).context(error::IoFailed { path: dir })?;
         }
         match profile.ty {
             AttrType::Template => {
                 let content = renderer.render(&profile.source)?;
-                std::fs::write(target, content).context(error::IoFailedContext {
+                std::fs::write(target, content).context(error::IoFailed {
                     path: &profile.source,
                 })?;
             }
             AttrType::Copy => std::fs::copy(&profile.source, target)
-                .context(error::IoFailedContext {
+                .context(error::IoFailed {
                     path: &profile.source,
                 })?
                 .ignore2(),

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,5 +1,4 @@
 use crate::{compile::CompiledEntries, error, profile::AttrType, template::Renderer};
-use dotfish::DotFish;
 use std::path::Path;
 use thisctx::WithContext;
 
@@ -28,11 +27,11 @@ pub fn apply(renderer: &mut Renderer, entries: &CompiledEntries) -> error::Resul
                     path: &profile.source,
                 })?;
             }
-            AttrType::Copy => std::fs::copy(&profile.source, target)
-                .context(error::IoFailed {
+            AttrType::Copy => {
+                std::fs::copy(&profile.source, target).context(error::IoFailed {
                     path: &profile.source,
-                })?
-                .ignore2(),
+                })?;
+            }
             AttrType::Link => create_symlink(&profile.source, target)?,
         }
     }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -97,7 +97,6 @@ fn compile_entry(
 mod tests {
     use super::*;
     use crate::profile::Profile;
-    use dotfish::DotFish;
     use std::path::Path;
 
     fn compile_str(source: &Path, profile: &str) -> error::Result<CompiledEntries> {
@@ -133,7 +132,7 @@ mod tests {
             .iter()
             .map(|filename| {
                 (
-                    "~/path/to/target".as_ref2::<Path>().join(filename),
+                    Path::new("~/path/to/target").join(filename),
                     CompiledProfile {
                         source: tmp.join("path/to/source").join(filename),
                         ty,

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,8 +5,9 @@ use thiserror::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Error, WithContext)]
-#[thisctx(visibility(pub(crate)))]
 #[thisctx(attr(derive(Debug)))]
+#[thisctx(visibility(pub(crate)))]
+#[thisctx(suffix(false))]
 pub enum Error {
     #[error("A linked or template file cannot have children: '{0}'")]
     UnexpectedChildren(PathBuf),

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -12,7 +12,7 @@ use std::{
     path::{Component, Path, PathBuf},
     rc::Rc,
 };
-use thisctx::WithContext;
+use thisctx::{IntoError, WithContext};
 
 pub type ProfileEntries = Vec<(PathBuf, ProfileAttr)>;
 
@@ -68,7 +68,7 @@ fn collect_entries_from_node(
         && !matches!(attr.recursive, Some(true))
         && !children.is_empty()
     {
-        return ().context(error::UnexpectedChildrenContext(full_target));
+        return error::UnexpectedChildren(full_target).fail();
     }
 
     // 3) Collect from child nodes.
@@ -178,7 +178,7 @@ impl ProfileAttrBuilder {
                     Some(builder) => builder
                         .build()
                         .ok()
-                        .context(error::InvalidPatternSetContext(target))?,
+                        .context(error::InvalidPatternSet(target))?,
                     None => <_>::default(),
                 },
             }))

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,4 +1,5 @@
 mod de;
+mod parse;
 
 use crate::{
     error,
@@ -221,34 +222,6 @@ where
     }
 }
 
-fn path_only_node<T>(source: T) -> ProfileNode
-where
-    T: Into<PathBuf>,
-{
-    ProfileNode {
-        attr: path_only_attr(source.into()),
-        ..Default::default()
-    }
-}
-
-fn normalize_path(path: &Path) -> Result<PathBuf, &'static str> {
-    let mut buf = PathBuf::new();
-    for compo in path.components() {
-        match compo {
-            Component::CurDir | Component::RootDir => (),
-            Component::ParentDir => {
-                buf.pop();
-            }
-            Component::Prefix(_) => return Err("a path can't start with a prefix"),
-            _ => buf.push(compo),
-        }
-    }
-    if buf.as_os_str().is_empty() {
-        return Err("a normalized path must not be empty");
-    }
-    Ok(buf)
-}
-
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct ComponentNode<'a> {
     attr: ProfileAttrBuilder,
@@ -258,22 +231,6 @@ struct ComponentNode<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn create_normalized_path() {
-        assert_eq!(
-            PathBuf::from("abc/def"),
-            normalize_path("skip/../abc/def".as_ref()).unwrap()
-        );
-        assert_eq!(
-            PathBuf::from("abc/def"),
-            normalize_path("/abc/def".as_ref()).unwrap()
-        );
-        assert_eq!(
-            PathBuf::from("abc/def"),
-            normalize_path("abc/./def".as_ref()).unwrap()
-        );
-    }
 
     fn create_component_node<'a, I>(entries: I) -> ComponentNode<'a>
     where

--- a/src/profile/parse.rs
+++ b/src/profile/parse.rs
@@ -200,7 +200,8 @@ impl<'a> Parser<'a> {
         self.buf_start();
         match self.next() {
             Some(ch) => match ch {
-                b'"' => self.next_string().map(Value::String),
+                b'"' => self.next_string(b'"').map(Value::String),
+                b'\'' => self.next_string(b'\'').map(Value::String),
                 ident_start!() => match self.next_ident() {
                     "true" => Ok(Value::True),
                     "false" => Ok(Value::False),
@@ -212,10 +213,10 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn next_string(&mut self) -> ParseResult<'a, &'a str> {
+    fn next_string(&mut self, quote: u8) -> ParseResult<'a, &'a str> {
         self.buf_start();
         while let Some(ch) = self.next() {
-            if ch == b'"' {
+            if ch == quote {
                 return Ok(self.buf_to(self.index - 1));
             }
         }
@@ -343,6 +344,10 @@ mod test {
 
         assert_eq!(
             parse_attribute(r#"<link source="path/to/source">"#).unwrap(),
+            expect_link_and_source("path/to/source")
+        );
+        assert_eq!(
+            parse_attribute(r#"<link source='path/to/source'>"#).unwrap(),
             expect_link_and_source("path/to/source")
         );
     }

--- a/src/profile/parse.rs
+++ b/src/profile/parse.rs
@@ -1,0 +1,307 @@
+use super::{path_only_attr, AttrType, ProfileAttrBuilder};
+use dotfish::DotFish;
+use std::path::{Component, Path, PathBuf};
+use tracing::{instrument, warn};
+
+pub(super) fn parse_attribute(s: &str) -> ParseResult<ProfileAttrBuilder> {
+    let mut parser = Parser {
+        index: 0,
+        start: 0,
+        source: s,
+    };
+    parser.parse()
+}
+
+struct Parser<'a> {
+    index: usize,
+    start: usize,
+    source: &'a str,
+}
+
+type ParseResult<T> = Result<T, String>;
+
+macro_rules! ident_pat {
+    () => {
+        b'a'..=b'z' | b'A'..=b'Z' | b'_'
+    };
+}
+
+impl<'a> Parser<'a> {
+    fn buf_start(&mut self) {
+        self.start = self.index;
+    }
+
+    fn buf_end(&self) -> &'a str {
+        self.buf_to(self.index)
+    }
+
+    fn buf_to(&self, end: usize) -> &'a str {
+        self.source.get(self.start..end).unwrap_unreachable2()
+    }
+
+    fn byte(&self) -> Option<u8> {
+        self.byte_at(self.index)
+    }
+
+    fn byte_at(&self, i: usize) -> Option<u8> {
+        self.source.as_bytes().get(i).copied()
+    }
+
+    fn char_at(&self, i: usize) -> Option<char> {
+        self.source.get(i..).unwrap_unreachable2().chars().next()
+    }
+
+    fn next(&mut self) -> Option<u8> {
+        if let Some(ch) = self.byte() {
+            self.advance();
+            Some(ch)
+        } else {
+            None
+        }
+    }
+
+    fn advance(&mut self) {
+        self.index += 1;
+    }
+
+    #[instrument(skip_all)]
+    fn parse(&mut self) -> ParseResult<ProfileAttrBuilder> {
+        self.skip_spaces();
+        if !matches!(self.next(), Some(b'<')) {
+            Ok(path_only_attr(normalize_path(self.source)?))
+        } else {
+            self.parse_xml_like()
+        }
+    }
+
+    fn parse_xml_like(&mut self) -> ParseResult<ProfileAttrBuilder> {
+        let mut attr = ProfileAttrBuilder::default();
+
+        self.skip_spaces();
+        match self.next_ident()? {
+            "copy" => attr.ty = Some(AttrType::Copy),
+            "link" => attr.ty = Some(AttrType::Link),
+            "template" => attr.ty = Some(AttrType::Template),
+            ty => return Err(format!("invalid type '{ty}'")),
+        }
+
+        loop {
+            self.skip_spaces();
+            match self.byte() {
+                Some(ch) => match ch {
+                    ident_pat!() => self.next_attribute(&mut attr)?,
+                    b'>' => break,
+                    _ => return Err(self.unexpected_char(self.index)),
+                },
+                None => return Err("unterminated angle brackets".to_owned()),
+            }
+        }
+        Ok(attr)
+    }
+
+    fn next_attribute(&mut self, attr: &mut ProfileAttrBuilder) -> ParseResult<()> {
+        macro_rules! check_dup {
+            ($name:ident) => {
+                if attr.$name.is_some() {
+                    return Err(format!("duplicate '{}' attribute", stringify!($name)));
+                }
+            };
+        }
+
+        let key = self.next_ident()?;
+        self.skip_spaces();
+        let val = if matches!(self.byte(), Some(b'=')) {
+            self.advance();
+            self.skip_spaces();
+            self.next_string()?
+        } else {
+            ""
+        };
+        match key {
+            "recursive" => {
+                check_dup!(recursive);
+                match val {
+                    "true" | "" => attr.recursive = Some(true),
+                    "false" => attr.recursive = Some(false),
+                    _ => return Err(format!("invalid 'recursive' value '{}'", val)),
+                }
+            }
+            "source" => {
+                check_dup!(source);
+                attr.source = Some(normalize_path(val)?)
+            }
+            _ => warn!("Undefined attribute '{}'", key),
+        }
+
+        Ok(())
+    }
+
+    fn next_ident(&mut self) -> ParseResult<&'a str> {
+        self.buf_start();
+        self.expect(|ch| matches!(ch, ident_pat!()))?;
+        while matches!(self.byte(), Some(ident_pat!() | b'0'..=b'9')) {
+            self.advance();
+        }
+        Ok(self.buf_end())
+    }
+
+    fn next_string(&mut self) -> ParseResult<&'a str> {
+        self.expect(|ch| ch == b'"')?;
+        self.buf_start();
+        while let Some(ch) = self.next() {
+            if ch == b'"' {
+                return Ok(self.buf_to(self.index - 1));
+            }
+        }
+        Err("unterminated string".to_owned())
+    }
+
+    fn skip_spaces(&mut self) {
+        while matches!(self.byte(), Some(b' ')) {
+            self.advance();
+        }
+    }
+
+    fn expect(&mut self, check: impl FnOnce(u8) -> bool) -> ParseResult<()> {
+        match self.next() {
+            Some(ch) => {
+                if check(ch) {
+                    Ok(())
+                } else {
+                    Err(self.unexpected_char(self.index - 1))
+                }
+            }
+            None => Err("unexpected end of string".to_owned()),
+        }
+    }
+
+    fn unexpected_char(&self, at: usize) -> String {
+        format!(
+            "unexpected character '{}' at {}",
+            self.char_at(at).unwrap_unreachable2(),
+            self.index,
+        )
+    }
+}
+
+pub fn normalize_path(path: &str) -> ParseResult<PathBuf> {
+    let mut buf = PathBuf::new();
+    for compo in path.as_ref2::<Path>().components() {
+        match compo {
+            Component::CurDir | Component::RootDir => (),
+            Component::ParentDir => {
+                buf.pop();
+            }
+            Component::Prefix(_) => return Err("a path can't start with a prefix".to_owned()),
+            _ => buf.push(compo),
+        }
+    }
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn create_normalized_path() {
+        assert_eq!(
+            PathBuf::from("abc/def"),
+            normalize_path("skip/../abc/def").unwrap()
+        );
+        assert_eq!(
+            PathBuf::from("abc/def"),
+            normalize_path("/abc/def").unwrap()
+        );
+        assert_eq!(
+            PathBuf::from("abc/def"),
+            normalize_path("abc/./def").unwrap()
+        );
+    }
+
+    fn type_only_attr(ty: AttrType) -> ProfileAttrBuilder {
+        ProfileAttrBuilder {
+            ty: Some(ty),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn parse_non_xml_like() {
+        assert_eq!(
+            parse_attribute("path/to/source").unwrap(),
+            path_only_attr("path/to/source")
+        );
+    }
+
+    #[test]
+    fn parse_type_only() {
+        assert_eq!(
+            parse_attribute("<template>").unwrap(),
+            type_only_attr(AttrType::Template)
+        );
+        assert_eq!(
+            parse_attribute("<link>").unwrap(),
+            type_only_attr(AttrType::Link)
+        );
+        assert_eq!(
+            parse_attribute("<copy>").unwrap(),
+            type_only_attr(AttrType::Copy)
+        );
+    }
+
+    #[test]
+    fn parse_recursive() {
+        fn expect_link_and_recursive(recursive: bool) -> ProfileAttrBuilder {
+            ProfileAttrBuilder {
+                ty: Some(AttrType::Link),
+                recursive: Some(recursive),
+                ..Default::default()
+            }
+        }
+        assert_eq!(
+            parse_attribute("<link recursive>").unwrap(),
+            expect_link_and_recursive(true)
+        );
+        assert_eq!(
+            parse_attribute(r#"<link recursive="true">"#).unwrap(),
+            expect_link_and_recursive(true)
+        );
+        assert_eq!(
+            parse_attribute(r#"<link recursive="false">"#).unwrap(),
+            expect_link_and_recursive(false)
+        );
+    }
+
+    #[test]
+    fn parse_source() {
+        fn expect_link_and_source(source: &str) -> ProfileAttrBuilder {
+            ProfileAttrBuilder {
+                ty: Some(AttrType::Link),
+                source: Some(source.into()),
+                ..Default::default()
+            }
+        }
+
+        assert_eq!(
+            parse_attribute("<link source>").unwrap(),
+            expect_link_and_source("")
+        );
+        assert_eq!(
+            parse_attribute(r#"<link source="path/to/source">"#).unwrap(),
+            expect_link_and_source("path/to/source")
+        );
+    }
+
+    #[test]
+    fn skip_spaces() {
+        let expected = ProfileAttrBuilder {
+            ty: Some(AttrType::Template),
+            source: Some("path/to/source".into()),
+            recursive: Some(false),
+            ..Default::default()
+        };
+        let s = r#"  <  template  recursive  =  "false"  source  =  "path/to/source"  >  "#;
+        assert_eq!(parse_attribute(s).unwrap(), expected);
+    }
+}

--- a/src/profile/parse.rs
+++ b/src/profile/parse.rs
@@ -1,5 +1,4 @@
 use super::{path_only_attr, AttrType, ProfileAttrBuilder};
-use dotfish::DotFish;
 use std::path::{Component, Path, PathBuf};
 use thisctx::IntoError;
 use tracing::{instrument, warn};
@@ -72,7 +71,9 @@ impl<'a> Parser<'a> {
     }
 
     fn buf_to(&self, end: usize) -> &'a str {
-        self.source.get(self.start..end).unwrap_unreachable2()
+        self.source
+            .get(self.start..end)
+            .unwrap_or_else(|| unreachable!())
     }
 
     fn byte(&self) -> Option<u8> {
@@ -84,11 +85,16 @@ impl<'a> Parser<'a> {
     }
 
     fn last_char(&self) -> char {
-        self.char_at(self.index - 1).unwrap_unreachable2()
+        self.char_at(self.index - 1)
+            .unwrap_or_else(|| unreachable!())
     }
 
     fn char_at(&self, i: usize) -> Option<char> {
-        self.source.get(i..).unwrap_unreachable2().chars().next()
+        self.source
+            .get(i..)
+            .unwrap_or_else(|| unreachable!())
+            .chars()
+            .next()
     }
 
     fn next(&mut self) -> Option<u8> {
@@ -238,7 +244,7 @@ impl<'a> Parser<'a> {
 
 pub(super) fn normalize_path(path: &str) -> ParseResult<PathBuf> {
     let mut buf = PathBuf::new();
-    for compo in path.as_ref2::<Path>().components() {
+    for compo in Path::new(path).components() {
         match compo {
             Component::CurDir | Component::RootDir => (),
             Component::ParentDir => {

--- a/src/template.rs
+++ b/src/template.rs
@@ -23,10 +23,10 @@ impl Renderer {
     }
 
     pub fn render(&mut self, path: &Path) -> error::Result<String> {
-        let content = std::fs::read_to_string(path).context(error::IoFailedContext { path })?;
+        let content = std::fs::read_to_string(path).context(error::IoFailed { path })?;
         self.tera
             .render_str(&content, &self.context)
-            .context(error::InvalidTemplateContext { path })
+            .context(error::InvalidTemplate { path })
     }
 }
 


### PR DESCRIPTION
Supports xml-like syntax profile strings.

## Example

```yaml
profile:
  path/to/target: <template source="path/to/source" recursive>
```